### PR TITLE
Migrations to drop volume and market_cap

### DIFF
--- a/app/models/bitcoin.rb
+++ b/app/models/bitcoin.rb
@@ -4,7 +4,6 @@ class Bitcoin < ApplicationRecord
             :high,
             :low,
             :close,
-            :volume,
             presence: true
 
   def self.average_yearly_open

--- a/app/models/ethereum.rb
+++ b/app/models/ethereum.rb
@@ -4,7 +4,6 @@ class Ethereum < ApplicationRecord
             :high,
             :low,
             :close,
-            :volume,
             presence: true
 
   def self.average_yearly_open
@@ -21,7 +20,7 @@ class Ethereum < ApplicationRecord
     group_by_year(:date)
     .average(:high)
   end
-  
+
   def self.average_monthly_high
     group_by_month(:date)
     .average(:high)

--- a/db/migrate/20171108220413_remove_volume_from_ethereums.rb
+++ b/db/migrate/20171108220413_remove_volume_from_ethereums.rb
@@ -1,0 +1,5 @@
+class RemoveVolumeFromEthereums < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :ethereums, :volume, :decimal
+  end
+end

--- a/db/migrate/20171108220438_remove_volume_from_bitcoins.rb
+++ b/db/migrate/20171108220438_remove_volume_from_bitcoins.rb
@@ -1,0 +1,5 @@
+class RemoveVolumeFromBitcoins < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :bitcoins, :volume, :decimal
+  end
+end

--- a/db/migrate/20171108220511_remove_market_cap_from_bitcoins.rb
+++ b/db/migrate/20171108220511_remove_market_cap_from_bitcoins.rb
@@ -1,0 +1,5 @@
+class RemoveMarketCapFromBitcoins < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :bitcoins, :market_cap, :decimal
+  end
+end

--- a/db/migrate/20171108220523_remove_market_cap_from_ethereums.rb
+++ b/db/migrate/20171108220523_remove_market_cap_from_ethereums.rb
@@ -1,0 +1,5 @@
+class RemoveMarketCapFromEthereums < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :ethereums, :market_cap, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171108171237) do
+ActiveRecord::Schema.define(version: 20171108220523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,6 @@ ActiveRecord::Schema.define(version: 20171108171237) do
     t.decimal "high"
     t.decimal "low"
     t.decimal "close"
-    t.decimal "volume"
-    t.decimal "market_cap"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -56,8 +54,6 @@ ActiveRecord::Schema.define(version: 20171108171237) do
     t.decimal "high"
     t.decimal "low"
     t.decimal "close"
-    t.decimal "volume"
-    t.decimal "market_cap"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,8 +22,6 @@ puts "Users seeded"
     b.high = row['High']
     b.low = row['Low']
     b.close = row['Close']
-    b.volume = row['Volume']
-    b.market_cap = row['Market Cap']
     b.save!
   end
 
@@ -36,8 +34,6 @@ puts "Users seeded"
      e.high = row['High']
      e.low = row['Low']
      e.close = row['Close']
-     e.volume = row['Volume']
-     e.market_cap = row['Market Cap']
      e.save!
   end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -12,8 +12,6 @@ task :import => [:environment] do
     b.high = row['High']
     b.low = row['Low']
     b.close = row['Close']
-    b.volume = row['Volume']
-    b.market_cap = row['Market Cap']
     b.save!
   end
 
@@ -26,8 +24,6 @@ task :import => [:environment] do
      e.high = row['High']
      e.low = row['Low']
      e.close = row['Close']
-     e.volume = row['Volume']
-     e.market_cap = row['Market Cap']
      e.save!
   end
 end


### PR DESCRIPTION
these migrations eliminate volume and market_cap from eth and btc tables
